### PR TITLE
chore: fixing get_interfaces() to support interfaces without line pro…

### DIFF
--- a/napalm_huawei_vrp/huawei_vrp.py
+++ b/napalm_huawei_vrp/huawei_vrp.py
@@ -311,7 +311,7 @@ class VRPDriver(NetworkDriver):
         # 定义执行命令
         fan_cmd = "display fan"
         """
-         Slot  FanID   Online    Status    Speed     Mode     Airflow            
+         Slot  FanID   Online    Status    Speed     Mode     Airflow
         -------------------------------------------------------------------------
          0     1       Present   Normal    55%       Auto     Side-to-Back
          1     1       Present   Normal    55%       Auto     Side-to-Back
@@ -321,10 +321,10 @@ class VRPDriver(NetworkDriver):
         ------------------------------------------------------------
          Slot    PowerID  Online   Mode   State      Power(W)
         ------------------------------------------------------------
-         0       PWR1     Present  AC     Supply     600.00     
-         0       PWR2     Present  AC     Supply     600.00     
-         1       PWR1     Present  AC     Supply     600.00     
-         1       PWR2     Present  AC     Supply     600.00  
+         0       PWR1     Present  AC     Supply     600.00
+         0       PWR2     Present  AC     Supply     600.00
+         1       PWR1     Present  AC     Supply     600.00
+         1       PWR2     Present  AC     Supply     600.00
         """
         temp_cmd = "display temperature all"
         """
@@ -339,7 +339,7 @@ class VRPDriver(NetworkDriver):
         """
         CPU Usage Stat. Cycle: 60 (Second)
         CPU Usage            : 28% Max: 87%
-        CPU Usage Stat. Time : 2022-01-13  18:57:06 
+        CPU Usage Stat. Time : 2022-01-13  18:57:06
         CPU utilization for five seconds: 28%: one minute: 28%: five minutes: 20%
         Max CPU Usage Stat. Time : 2021-10-05 17:50:44.
         """
@@ -618,15 +618,17 @@ class VRPDriver(NetworkDriver):
             match_intf = re.search(re_intf_name_state, interface, flags=re.M)
             match_proto = re.search(re_protocol, interface, flags=re.M)
 
-            if match_intf is None or match_proto is None:
+            if match_intf is None:
                 msg = "Unexpected interface format: {}".format(interface)
                 raise ValueError(msg)
             intf_name = match_intf.group("intf_name")
             intf_state = match_intf.group("intf_state")
             is_enabled = bool("up" in intf_state.lower())
 
-            protocol = match_proto.group("protocol")
-            is_up = bool("up" in protocol.lower())
+            is_up = False
+            if match_proto:
+                protocol = match_proto.group("protocol")
+                is_up = bool("up" in protocol.lower())
 
             match_mac = re.search(re_mac, interface, flags=re.M)
             if match_mac:


### PR DESCRIPTION
This PR is to adjust logic to support interfaces without "Line Protocol" in the "display interfaces" output, for example, Virtual-Ethernet interfaces configured in layer-2 mode.
Example:
```
Subtask: napalm_get (failed)

---- napalm_get ** changed : False --------------------------------------------- ERROR
Traceback (most recent call last):
  File "/Users/hgaliza/Library/Caches/pypoetry/virtualenvs/remessa-FeQPNv6p-py3.11/lib/python3.11/site-packages/nornir/core/task.py", line 99, in start
    r = self.task(self, **self.params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hgaliza/Library/Caches/pypoetry/virtualenvs/remessa-FeQPNv6p-py3.11/lib/python3.11/site-packages/nornir_napalm/plugins/tasks/napalm_get.py", line 44, in napalm_get
    result[g] = method(**options)
                ^^^^^^^^^^^^^^^^^
  File "/Users/hgaliza/workspace/napalm-huawei-vrp/napalm_huawei_vrp/huawei_vrp.py", line 623, in get_interfaces
    raise ValueError(msg)
ValueError: Unexpected interface format: Virtual-Ethernet0/0/1 current state : UP
Description:
Route Port,The Maximum Transmit Unit is 1500
Internet protocol processing : disabled
IP Sending Frames' Format is PKTFMT_ETHNT_2, Hardware address is c4e2-8720-b160
Current system time: 2024-06-15 07:51:39-03:00
    Input bandwidth utilization  :    0%
    Output bandwidth utilization :    0%

```
Interface configuration, for reference:

```
dis cur int Virtual-Ethernet 0/0/1
#
interface Virtual-Ethernet0/0/1
 ve-group 1 l2-terminate
#
```

After this fix:

```
---- napalm_get ** changed : False --------------------------------------------- INFO
{ 'get_interfaces': { 'Virtual-Ethernet0/0/1': { 'description': '',
                                                 'is_enabled': True,
                                                 'is_up': False,
                                                 'last_flapped': -1.0,
                                                 'mac_address': 'C4:E2:87:20:B1:60',
                                                 'mtu': 1500,
                                                 'speed': -1.0},
(...)
```
